### PR TITLE
Update footer email and add TL;DR label to post summaries

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,6 +36,7 @@
 
   {{- if .Params.tldr }}
   <div class="post-summary">
+    <strong>TL;DR</strong>
     <ul>
       {{- range .Params.tldr }}
       <li>{{ . | markdownify }}</li>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 <footer class="footer">
     <span>&copy; {{ now.Year }} {{ site.Title }}</span>
     {{- print " · " }}
-    <span>chiodinostefano at gmail.com</span>
+    <span>my surname, followed by my name, at gmail.com</span>
 </footer>
 {{- end }}
 


### PR DESCRIPTION
## Summary
This PR makes two minor updates to improve the footer and post summary presentation:

## Key Changes
- **Footer email**: Updated the hardcoded email address in the footer to a placeholder format (`my surname, followed by my name, at gmail.com`) instead of the specific email address
- **Post summary label**: Added a `<strong>TL;DR</strong>` label above the summary list in single post layouts to make the purpose of the summary section more explicit to readers

## Implementation Details
- The footer change makes the email display more generic/template-like, which may be useful for theme distribution or privacy purposes
- The TL;DR label is wrapped in a `<strong>` tag for visual emphasis and is placed directly before the existing summary list items

https://claude.ai/code/session_01VTygfQTSnCmp4jcmUyNRrB